### PR TITLE
CI-Test: Update ods-ci test setup for ODH Dashboard 2.8.0 release

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -3,22 +3,23 @@ FROM quay.io/centos/centos:stream8
 ARG ORG=opendatahub-io
 ARG BRANCH=master
 ARG ODS_CI_REPO=https://github.com/red-hat-data-services/ods-ci
-ARG ODS_CI_GITREF=master
+# This git reference should always reference a stable commit from ods-ci that supports ODH
+ARG ODS_CI_GITREF=a0d8e0a8cf58629f895a1660c5d766c3aa4ce82e
 ARG OC_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/latest/openshift-client-linux.tar.gz
 
 ENV HOME /root
 WORKDIR /root
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
-    dnf install -y bc git go-toolset python38 unzip chromium chromedriver && \
+    dnf install -y jq bc git go-toolset python38 unzip chromium chromedriver && \
     dnf clean all && \
     git clone https://github.com/opendatahub-io/peak $HOME/peak && \
     cd $HOME/peak && \
     git submodule update --init
 
-# install jq to help with parsing json
-RUN curl -o /usr/local/bin/jq http://stedolan.github.io/jq/download/linux64/jq && \
-    chmod +x /usr/local/bin/jq
+# install yq to help with parsing json
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq &&\
+    chmod +x /usr/bin/yq
 
 RUN mkdir -p $HOME/src && \
     cd $HOME/src && \
@@ -39,6 +40,12 @@ RUN pip3 install micropipenv &&\
     ln -s `which pip3` /usr/bin/pip &&\
     cd $HOME/peak &&\
     micropipenv install
+
+# Install poetry to support the exeuction of ods-ci test framework
+RUN curl -sSL https://install.python-poetry.org | python3 -
+ENV PATH="${PATH}:$HOME/.local/bin"
+RUN cd $HOME/src/ods-ci && poetry install
+    
 
 COPY setup/operatorsetup scripts/install.sh scripts/installandtest.sh $HOME/peak/
 COPY resources $HOME/peak/operator-tests/odh-manifests/resources

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -10,7 +10,7 @@ ENV HOME /root
 WORKDIR /root
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
-    dnf install -y bc git go-toolset python3-pip python3-devel unzip chromium chromedriver && \
+    dnf install -y bc git go-toolset python38 unzip chromium chromedriver && \
     dnf clean all && \
     git clone https://github.com/opendatahub-io/peak $HOME/peak && \
     cd $HOME/peak && \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,9 +4,9 @@ GIT_ORG=opendatahub-io
 GIT_BRANCH=master
 # Project where ODH is deployed
 ODHPROJECT=opendatahub
-# Specify the repo and git ref/branch to use for cloning ods-ci repo for the automation
+# Specify the repo and git ref/branch to use for cloning ods-ci repo for the automation that works when running against an ODH deployment
 ODS_CI_REPO=https://github.com/red-hat-data-services/ods-ci
-ODS_CI_GITREF=master
+ODS_CI_GITREF=a0d8e0a8cf58629f895a1660c5d766c3aa4ce82e
 OC_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/latest/openshift-client-linux.tar.gz
 # Authentication info for the OCP test user account that can be used in the test automation
 # For all tests, the expectation is that this is used for normal end-user access to the cluster

--- a/tests/basictests/dashboard.sh
+++ b/tests/basictests/dashboard.sh
@@ -61,10 +61,11 @@ function test_odh_dashboard_ui() {
     header "Running ODS-CI automation"
 
     os::cmd::expect_success "oc project ${ODHPROJECT}"
-    pushd ${HOME}/src/ods-ci
+    # Navigate to the base directory where we will run the ods-ci test script
+    pushd ${HOME}/src/ods-ci/ods_ci
     #TODO: Add a test that will iterate over all of the notebook using the notebooks in https://github.com/opendatahub-io/testing-notebooks
     # Execute the ods-ci robotframework automation to verify that we can spawn a notebook
-    os::cmd::expect_success "run_robot_test.sh --skip-oclogin true --test-artifact-dir ${ARTIFACT_DIR} \
+    os::cmd::expect_success "run_robot_test.sh --skip-install --skip-oclogin true --test-artifact-dir ${ARTIFACT_DIR} \
       --test-case ${MY_DIR}/../resources/ods-ci/test-odh-dashboard-jupyterlab-notebook.robot \
       --test-variables-file ${MY_DIR}/../resources/ods-ci/test-variables.yml \
       --test-variable 'ODH_DASHBOARD_URL:${ODH_DASHBOARD_URL}' \

--- a/tests/resources/ods-ci/test-odh-dashboard-jupyterlab-notebook.robot
+++ b/tests/resources/ods-ci/test-odh-dashboard-jupyterlab-notebook.robot
@@ -57,7 +57,7 @@ Can Launch Python3 Smoke Test Notebook
 #TODO: Update ods-ci to support ODH builds of dashboard and associated components
 *** Keywords ***
 Wait for ODH Dashboard to Load
-    [Arguments]  ${dashboard_title}="Open Data Hub"   ${odh_logo_xpath}=//img[@alt="Open Data Hub Logo"]
+    [Arguments]  ${dashboard_title}="${ODH_DASHBOARD_PROJECT_NAME}"   ${odh_logo_xpath}=//img[@alt="${ODH_DASHBOARD_PROJECT_NAME} Logo"]
     Wait For Condition    return document.title == ${dashboard_title}    timeout=15s
     Wait Until Page Contains Element    xpath:${odh_logo_xpath}    timeout=15s
 
@@ -74,7 +74,7 @@ Begin ODH Web Test
     Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ${authorization_required} =  Is Service Account Authorization Required
     Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
-    Wait for ODH Dashboard to Load
+    Wait for RHODS Dashboard to Load
 
     # Workaround for issues when the dashboard reports "No Components Found" on the initial load
     Wait Until Element Is Not Visible  xpath://h5[.="No Components Found"]   120seconds
@@ -84,7 +84,6 @@ Begin ODH Web Test
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     Fix Spawner Status
     Go To  ${ODH_DASHBOARD_URL}
-
 
 Verify Notebook Name And Image Tag
     [Documentation]    Verifies that expected notebook is spawned and image tag is not latest

--- a/tests/resources/ods-ci/test-variables.yml
+++ b/tests/resources/ods-ci/test-variables.yml
@@ -3,6 +3,8 @@ BROWSER:
   # List of Chrome options - https://peter.sh/experiments/chromium-command-line-switches/
   # --disable-dev-shm-usage  and --no-sandbox are required for running chromedriver in a container
   OPTIONS: add_argument("--ignore-certificate-errors");add_argument("window-size=1920,1024");add_argument("--disable-dev-shm-usage");add_argument("--no-sandbox")
+# Override the project name that is used when checking if the current page is ODH Dashboard
+ODH_DASHBOARD_PROJECT_NAME: "Open Data Hub"
 OCP_API_URL: "https://api.my-cluster.test.redhat.com:my-port"
 OCP_CONSOLE_URL: "http://console-openshift-console.apps.my-cluster.test.redhat.com/"
 ODH_DASHBOARD_URL: "http://odh-dashboard-opendatahub.apps.my-cluster.test.redhat.com/"


### PR DESCRIPTION
Update the odh-manfiest test container and ods-ci testcase to work with ODH test runs